### PR TITLE
consumer transformers

### DIFF
--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -1,4 +1,6 @@
 import { type State, createHandler, subscribe } from "../state";
+import { skipDuplicates, perTick } from "../transformers";
+import { pull, compose } from "../util";
 import { ensureConnection, removeWsListeners } from "./ensureConnection";
 import { type Effect } from "./types";
 
@@ -7,17 +9,14 @@ import { type Effect } from "./types";
  * they actually perform a side effect. All side effects should happen here. Typically they will
  * do something conditionally, and usually will return the same state because they did no side effects.
  */
-
 const setState = createHandler((_oldState, newState: State) => newState);
 
 const effects: Effect[] = [ensureConnection, removeWsListeners];
 
-subscribe((state) => {
-  let newState = state;
-  for (const effect of effects) {
-    newState = effect(newState);
-  }
-  if (newState !== state) {
-    setState(newState);
-  }
+const subscribeEffects = pull(
+  compose(skipDuplicates<State>(), perTick<State>())
+)(subscribe);
+
+subscribeEffects((state) => {
+  setState(effects.reduce((newState, effect) => effect(newState), state));
 });

--- a/src/transformers.ts
+++ b/src/transformers.ts
@@ -1,0 +1,34 @@
+import { type ConsumerTransformer, type Scheduler } from "./types";
+
+const makeThrottler =
+  <T>(scheduleWork: Scheduler): ConsumerTransformer<T> =>
+  (consumer) => {
+    let workScheduled = false;
+    let latestValue: T;
+    return (t: T) => {
+      latestValue = t;
+      if (!workScheduled) {
+        scheduleWork(() => {
+          consumer(latestValue);
+          workScheduled = false;
+        });
+      }
+    };
+  };
+
+export const perTick = <T>(): ConsumerTransformer<T> =>
+  makeThrottler(queueMicrotask);
+export const perAnimationFrame = <T>(): ConsumerTransformer<T> =>
+  makeThrottler(requestAnimationFrame);
+
+export const skipDuplicates =
+  <T>(): ConsumerTransformer<T> =>
+  (consumer) => {
+    let lastValue: T;
+    return (t: T) => {
+      if (t !== lastValue) {
+        lastValue = t;
+        consumer(t);
+      }
+    };
+  };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,6 @@
 export type Consumer<T> = (t: T) => void;
+export type ConsumerTransformer<T, S = T> = (
+  mapper: Consumer<T>
+) => Consumer<S>;
+export type Callback = () => void;
+export type Scheduler = Consumer<Callback>;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,9 @@
+export const pull =
+  <A, B>(f: (a: A) => B) =>
+  <C>(g: (b: B) => C) =>
+  (a: A) =>
+    g(f(a));
+export const compose =
+  <A, B, C>(g: (b: B) => C, f: (a: A) => B) =>
+  (a: A) =>
+    g(f(a));


### PR DESCRIPTION
In #1 we introduced `Effects`. There is an issue: when they change the state, the will immediately be called again with the new state adding a stack frame. I wanted a generic way to transform the behavior of any state consumer. We can throttle consumers to only see the latest value per tick or per animation frame, and one to not provide duplicate values.

