### PR TITLE
better subscription configuration

### DIFF
--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -1,6 +1,5 @@
 import { type State, createHandler, subscribe } from "../state";
 import { skipDuplicates, perTick } from "../transformers";
-import { pull, compose } from "../util";
 import { ensureConnection, removeWsListeners } from "./ensureConnection";
 import { type Effect } from "./types";
 
@@ -13,9 +12,7 @@ const setState = createHandler((_oldState, newState: State) => newState);
 
 const effects: Effect[] = [ensureConnection, removeWsListeners];
 
-const subscribeEffects = pull(
-  compose(skipDuplicates<State>(), perTick<State>())
-)(subscribe);
+const subscribeEffects = subscribe.with(skipDuplicates()).with(perTick());
 
 subscribeEffects((state) => {
   setState(effects.reduce((newState, effect) => effect(newState), state));

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,6 +1,7 @@
 import { initState } from "./state-management";
 import { type BrandString, BetterRecord } from "./type-util";
 import { type RecordOf, List } from "immutable";
+import { makeConfigurable } from "./util";
 
 export const makePlayerStatus = BetterRecord<
   PlayerStatusProps,
@@ -36,9 +37,12 @@ export const makeConnectingState = BetterRecord<ConnectingStateProps, "ws">({
   ws: undefined,
 });
 
-export const { createHandler, subscribe, unsubscribe } = initState<State>(
+const { createHandler, subscribe: baseSubscribe } = initState<State>(
   makeDisconnectedState()
 );
+
+export { createHandler };
+export const subscribe = makeConfigurable(baseSubscribe);
 
 export type State = ConnectedState | DisconnectedState | ConnectingState;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,15 @@
-export const pull =
-  <A, B>(f: (a: A) => B) =>
-  <C>(g: (b: B) => C) =>
-  (a: A) =>
-    g(f(a));
-export const compose =
-  <A, B, C>(g: (b: B) => C, f: (a: A) => B) =>
-  (a: A) =>
-    g(f(a));
+type ConfigurableFunction<A, B> = {
+  with: <C>(transformer: (c: C) => A) => ConfigurableFunction<C, B>;
+  (a: A): B;
+};
+
+export const makeConfigurable = <A, B>(
+  f: (a: A) => B
+): ConfigurableFunction<A, B> => Object.assign(f, { with: withProperty });
+
+function withProperty<A, B, C>(
+  this: (a: A) => B,
+  transformer: (c: C) => A
+): ConfigurableFunction<C, B> {
+  return makeConfigurable((c: C) => this(transformer(c)));
+}


### PR DESCRIPTION
`pull` and `compose` were not great for readability.