### PR TITLE
time coeffect

### DIFF
--- a/src/coeffects/time.ts
+++ b/src/coeffects/time.ts
@@ -1,0 +1,10 @@
+import { makeCoeffect } from ".";
+import type { ConsumerTransformer } from "../types";
+
+export const time = <T extends unknown[]>(
+  millis: number
+): ConsumerTransformer<[...T, Date], T> => {
+  const { transformer, trigger } = makeCoeffect<T, Date>(() => new Date());
+  setInterval(trigger, millis);
+  return transformer;
+};

--- a/src/effects/ensureConnection.ts
+++ b/src/effects/ensureConnection.ts
@@ -56,12 +56,12 @@ const handleMessage = createHandler((state, e: MessageEvent) => {
   return state;
 });
 
-export const ensureConnection: Effect = (state) => {
+export const ensureConnection: Effect = (state, now) => {
   if (
     state.websocketStatus === "disconnected" &&
     state.ws === undefined &&
     (state.failureAt === undefined ||
-      state.failureAt.getTime() < Date.now() - RECONNECT_MS)
+      state.failureAt.getTime() < now.getTime() - RECONNECT_MS)
   ) {
     const ws = new WebSocket(WS_URL);
     ws.addEventListener("close", setDisconnected);

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -1,3 +1,4 @@
+import { time } from "../coeffects/time";
 import { type State, createHandler, subscribe } from "../state";
 import { skipDuplicates, perTick } from "../transformers";
 import { ensureConnection, removeWsListeners } from "./ensureConnection";
@@ -12,8 +13,11 @@ const setState = createHandler((_oldState, newState: State) => newState);
 
 const effects: Effect[] = [ensureConnection, removeWsListeners];
 
-const subscribeEffects = subscribe.with(skipDuplicates()).with(perTick());
+const subscribeEffects = subscribe
+  .with(time(1000))
+  .with(skipDuplicates())
+  .with(perTick());
 
-subscribeEffects((state) => {
-  setState(effects.reduce((newState, effect) => effect(newState), state));
+subscribeEffects((state, now) => {
+  setState(effects.reduce((newState, effect) => effect(newState, now), state));
 });

--- a/src/effects/types.ts
+++ b/src/effects/types.ts
@@ -1,3 +1,3 @@
 import { type State } from "../state";
 
-export type Effect = (state: State) => State;
+export type Effect = (state: State, now: Date) => State;

--- a/src/state.ts
+++ b/src/state.ts
@@ -115,6 +115,3 @@ export const makeIntentHandler = <T extends unknown[]>(
         return s.update("pendingIntents", (intents) => intents.push(intent));
     }
   });
-
-const tick = createHandler((state) => state);
-setInterval(tick, 1000);


### PR DESCRIPTION
Makes the current time available to effects, and use it instead of calling `new Date()`